### PR TITLE
Add new static method: void setReadTimeouts(long start_response_timeout, long msg_char_timeout)

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,6 +14,7 @@ LSS	KEYWORD1
 
 initBus	KEYWORD2
 closeBus	KEYWORD2
+setReadTimeouts	KEYWORD2
 genericWrite	KEYWORD2
 genericRead_Blocking_s16	KEYWORD2
 genericRead_Blocking_str	KEYWORD2
@@ -62,6 +63,7 @@ getAngularHoldingStiffness	KEYWORD2
 getAngularAcceleration	KEYWORD2
 getAngularDeceleration	KEYWORD2
 getIsMotionControlEnabled	KEYWORD2
+getFilterPositionCount	KEYWORD2
 getBlinkingLED	KEYWORD2
 
 setOriginOffset	KEYWORD2
@@ -79,6 +81,7 @@ setAngularHoldingStiffness	KEYWORD2
 setAngularAcceleration	KEYWORD2
 setAngularDeceleration	KEYWORD2
 setIsMotionControlEnabled	KEYWORD2
+setFilterPositionCount	KEYWORD2
 setBlinkingLED	KEYWORD2
 
 #######################################
@@ -201,6 +204,7 @@ LSS_ConfigMaxSpeed	LITERAL1
 LSS_ConfigMaxSpeedRPM	LITERAL1
 LSS_ConfigColorLED	LITERAL1
 LSS_ConfigGyreDirection	LITERAL1
+LSS_ConfigFilterPositionCount	LITERAL1
 LSS_ConfigFirstPosition	LITERAL1
 LSS_ConfigAngularStiffness	LITERAL1
 LSS_ConfigAngularHoldingStiffness	LITERAL1

--- a/src/LSS.cpp
+++ b/src/LSS.cpp
@@ -1288,6 +1288,26 @@ bool LSS::setMotionControlEnabled(bool value)
 	return (LSS::genericWrite(this->servoID, LSS_ActionEnableMotionControl, value));
 }
 
+bool LSS::setFilterPositionCount(int16_t value, LSS_SetType setType)
+{
+	
+	switch (setType)
+	{
+		case (LSS_SetSession):
+		{
+			return (LSS::genericWrite(this->servoID, LSS_FilterPositionCount, value));
+			break;
+		}
+		case (LSS_SetConfig):
+		{
+			return (LSS::genericWrite(this->servoID, LSS_ConfigFilterPositionCount, value));
+			break;
+		}
+	}
+	return false;
+}
+
+
 bool LSS::setBlinkingLED(uint8_t value)
 {
 	return (LSS::genericWrite(this->servoID, LSS_ConfigBlinkingLED, value));

--- a/src/LSS.cpp
+++ b/src/LSS.cpp
@@ -1027,6 +1027,25 @@ bool LSS::getIsMotionControlEnabled(void)
 	return (value);
 }
 
+int16_t LSS::getFilterPositionCount(LSS_QueryType queryType = LSS_QuerySession) {
+	// Variables
+	int16_t value = 0;
+
+	// Ask servo for status; exit if it failed
+	if (!(LSS::genericWrite(this->servoID, LSS_QueryFilterPositionCount, queryType)))
+	{
+		LSS::lastCommStatus = LSS_CommStatus_WriteNoBus;
+		return (value);
+	}
+
+	// Read response from servo
+	value = (int16_t) LSS::genericRead_Blocking_s16(this->servoID, LSS_QueryFilterPositionCount);
+
+	// Return result
+	return (value);
+	
+}
+
 uint8_t LSS::getBlinkingLED(void)
 {
 	// Variables

--- a/src/LSS.cpp
+++ b/src/LSS.cpp
@@ -17,6 +17,7 @@
 bool LSS::hardwareSerial;
 Stream * LSS::bus;
 LSS_LastCommStatus LSS::lastCommStatus = LSS_CommStatus_Idle;
+long LSS::_msg_char_timeout = LSS_Timeout;
 
 //> Command reading/writing
 volatile unsigned int LSS::readID;  // sscanf - assumes this
@@ -45,6 +46,13 @@ LSS::~LSS(void)
 
 // -- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 // Public functions (class)    ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+void LSS::setReadTimeouts(long start_response_timeout, long msg_char_timeout)
+{
+	_msg_char_timeout = msg_char_timeout;
+	bus->setTimeout(start_response_timeout);
+
+}
+
 
 int LSS::timedRead(void)
 {
@@ -55,7 +63,7 @@ int LSS::timedRead(void)
 		c = LSS::bus->read();
 		if (c >= 0)
 			return (c);
-	} while (millis() - startMillis < LSS_Timeout);
+	} while (millis() - startMillis < _msg_char_timeout);
 	return (-1);     // -1 indicates timeout
 }
 

--- a/src/LSS.h
+++ b/src/LSS.h
@@ -312,6 +312,7 @@ public:
 	int16_t getAngularAcceleration(LSS_QueryType queryType = LSS_QuerySession);
 	int16_t getAngularDeceleration(LSS_QueryType queryType = LSS_QuerySession);
 	bool getIsMotionControlEnabled(void);
+	int16_t getFilterPositionCount(LSS_QueryType queryType = LSS_QuerySession);
 	uint8_t getBlinkingLED(void);
 
 	//> Configs

--- a/src/LSS.h
+++ b/src/LSS.h
@@ -33,6 +33,7 @@
 #endif
 
 // Constants
+#define LSS_SupportsSettingTimeouts
 //> String processing
 #define IS_AF(c)					((c >= 'A') && (c <= 'F'))
 #define IS_af(c)					((c >= 'a') && (c <= 'f'))
@@ -236,6 +237,7 @@ class LSS
 {
 public:
 	// Public functions - Class
+	static void setReadTimeouts(long start_response_timeout=LSS_Timeout, long msg_char_timeout=LSS_Timeout);
 	static int timedRead(void);
 	bool charToInt(char * inputstr, int32_t * intnum);
 	//static void initBus(Stream &, uint32_t);
@@ -339,7 +341,7 @@ private:
 	static LSS_LastCommStatus lastCommStatus;
 	static volatile unsigned int readID;
 	static char value[24];
-
+	static long _msg_char_timeout;   // timeout waiting for characters inside of packet
 	// Private functions - Instance
 
 	// Private attributes - Instance

--- a/src/LSS.h
+++ b/src/LSS.h
@@ -180,6 +180,7 @@ enum LSS_LED_Color
 #define LSS_ActionAngularAcceleration		("AA")
 #define LSS_ActionAngularDeceleration		("AD")
 #define LSS_ActionEnableMotionControl		("EM")
+#define LSS_FilterPositionCount				("FPC")
 
 //> Commands - queries
 #define LSS_QueryStatus				("Q")
@@ -211,6 +212,7 @@ enum LSS_LED_Color
 #define LSS_QueryAngularAcceleration		("QAA")
 #define LSS_QueryAngularDeceleration		("QAD")
 #define LSS_QueryEnableMotionControl		("QEM")
+#define LSS_QueryFilterPositionCount		("QFPC")
 #define LSS_QueryBlinkingLED				("QLB")
 
 //> Commands - configurations
@@ -224,6 +226,7 @@ enum LSS_LED_Color
 #define LSS_ConfigGyreDirection				("CG")
 #define LSS_ConfigFirstPosition				("CFD")
 #define LSS_ConfigModeRC					("CRC")
+#define LSS_ConfigFilterPositionCount		("CFPC")
 
 //> Commands - configurations (advanced)
 #define LSS_ConfigAngularStiffness			("CAS")
@@ -328,6 +331,7 @@ public:
 	bool setAngularAcceleration(int16_t value, LSS_SetType setType = LSS_SetSession);
 	bool setAngularDeceleration(int16_t value, LSS_SetType setType = LSS_SetSession);
 	bool setMotionControlEnabled(bool value);
+	bool setFilterPositionCount(int16_t value, LSS_SetType setType = LSS_SetSession);
 	bool setBlinkingLED(uint8_t value);
 
 	// Public attributes - Instance


### PR DESCRIPTION
This method allows you to set two different timeout values to be used for waiting for a response for a query.
Currently the timeouts are hard coded to 100ms which is way too long for most usage patterns.

The two timeouts are setup to work: with the first one used by the code that waits for the start of a response character *
The second timeout is how long to wait for each of the subsequent characters in a response.

I also added a define: #define LSS_SupportsSettingTimeouts

That sketches can check exists before calling new method as to allow them to still run on older libraries.  Without a sketch calling this method, there should be no differences in operation of the library.

This update can help minimize some timing issues that sketches are running into with the current firmware.  While later updated firmware will hopefully minimize the issues needing the 2nd timeout, sketches will still benefit from the ability to set their own timeout values. 