### PR TITLE
Remove compiler warnings.

### DIFF
--- a/src/LSS.cpp
+++ b/src/LSS.cpp
@@ -17,7 +17,7 @@
 bool LSS::hardwareSerial;
 Stream * LSS::bus;
 LSS_LastCommStatus LSS::lastCommStatus = LSS_CommStatus_Idle;
-long LSS::_msg_char_timeout = LSS_Timeout;
+uint32_t LSS::_msg_char_timeout = LSS_Timeout;
 
 //> Command reading/writing
 volatile unsigned int LSS::readID;  // sscanf - assumes this
@@ -46,7 +46,7 @@ LSS::~LSS(void)
 
 // -- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 // Public functions (class)    ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
-void LSS::setReadTimeouts(long start_response_timeout, long msg_char_timeout)
+void LSS::setReadTimeouts(uint32_t start_response_timeout, uint32_t msg_char_timeout)
 {
 	_msg_char_timeout = msg_char_timeout;
 	bus->setTimeout(start_response_timeout);
@@ -1027,7 +1027,7 @@ bool LSS::getIsMotionControlEnabled(void)
 	return (value);
 }
 
-int16_t LSS::getFilterPositionCount(LSS_QueryType queryType = LSS_QuerySession) {
+int16_t LSS::getFilterPositionCount(LSS_QueryType queryType) {
 	// Variables
 	int16_t value = 0;
 

--- a/src/LSS.h
+++ b/src/LSS.h
@@ -240,7 +240,7 @@ class LSS
 {
 public:
 	// Public functions - Class
-	static void setReadTimeouts(long start_response_timeout=LSS_Timeout, long msg_char_timeout=LSS_Timeout);
+	static void setReadTimeouts(uint32_t start_response_timeout=LSS_Timeout, uint32_t msg_char_timeout=LSS_Timeout);
 	static int timedRead(void);
 	bool charToInt(char * inputstr, int32_t * intnum);
 	//static void initBus(Stream &, uint32_t);
@@ -346,7 +346,7 @@ private:
 	static LSS_LastCommStatus lastCommStatus;
 	static volatile unsigned int readID;
 	static char value[24];
-	static long _msg_char_timeout;   // timeout waiting for characters inside of packet
+	static uint32_t _msg_char_timeout;   // timeout waiting for characters inside of packet
 	// Private functions - Instance
 
 	// Private attributes - Instance


### PR DESCRIPTION
Sorry,

Looks like the newer stuff I added caused some compiler warnings, when I did a clean build. So this should hopefully remove them.

Note: There is still a compile warning for running on AVR boards, about converting from string constants to char *.... But this is not related to my changes